### PR TITLE
chore: Remove unused PropsWithChildren from Loader component

### DIFF
--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { Size } from '../models';
 
@@ -9,7 +9,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
   text?: string;
 }
 
-export const Loader: React.FC<PropsWithChildren<IProps>> = ({
+export const Loader: React.FC<IProps> = ({
   background = 'light',
   size = 8,
   overlay = false,


### PR DESCRIPTION
This PR removes the PropsWithChildren type from the Loader component as it is not being utilized. The children prop was initially included in the Loader component's props but it was never used within the component.